### PR TITLE
fixed issue #19 - unable to create voting when using a harmony dao and using approval - based voting

### DIFF
--- a/src/store/modules/app.ts
+++ b/src/store/modules/app.ts
@@ -552,7 +552,14 @@ const actions = {
           for (const choiceIndex in choices) {
             // deep copy vote result warp
             const voteItem = JSON.parse(JSON.stringify(votes[address]));
-            voteItem.msg.payload.choice = parseInt(choices[choiceIndex]);
+            // if proposal is single choice, or its not defined and maxCanSelect is <= 1 then its a single-choice and hence an int
+            if (proposal.msg.payload.metadata.voting === 'single-choice' || 
+              (!proposal.msg.payload.metadata.voting && (isNaN(+proposal.msg.payload.maxCanSelect)) || +proposal.msg.payload.maxCanSelect <= 1)) { 
+              voteItem.msg.payload.choice = parseInt(choices[choiceIndex]); // single choice means vote is an int
+            }
+            else {
+              voteItem.msg.payload.choice = [parseInt(choices[choiceIndex])]; // else it should be an array
+            }
             votesResult.push(voteItem);
           }
         }


### PR DESCRIPTION
Fixes #19 
https://github.com/harmony-one/snapshot/issues/19

Test case: https://gov.harmony.one/#/harmony-creative-dao/proposal/QmZ6xiTHv7RYkCnbThNAi4Knxm2kMiXUgdRQXYU4v9UY1P

Changes proposed in this pull request:
- special condition for the harmony daos
- consideration for single-voting, backwards compatibility, and existing (new and old) votes

The issue was caused by processing of votes treated as "single-vote" with single select that was mixed up with approval-based voting. When it is related to single-vote and is a harmony dao, we convert it to a numerical vote. Other than single-vote; everything else requires array values. So i put a condition to check this.

Condition is complex because it checks for
1. single-vote (must be single int)
2. historic votes (no type, but can have either canMultiSelect > 1 which is approval and require array, or canMultiSelect is not defined or 0 which require single int)


